### PR TITLE
Exercise 3.8 adjustment and Chp2 video removal 

### DIFF
--- a/_sources/PythonTurtle/Exercises.rst
+++ b/_sources/PythonTurtle/Exercises.rst
@@ -197,6 +197,7 @@ Exercises
            import turtle
            wn = turtle.Screen()
            tess = turtle.Turtle()
+           tess.speed(5)
            tess.right(90)
            tess.left(3600)
            tess.right(-90)

--- a/_sources/SimplePythonData/StatementsandExpressions.rst
+++ b/_sources/SimplePythonData/StatementsandExpressions.rst
@@ -14,13 +14,6 @@
 Statements and Expressions
 --------------------------
 
-.. video:: expression_vid
-    :controls:
-    :thumb: ../_static/expressions.png
-
-    http://media.interactivepython.org/thinkcsVideos/Expressions.mov
-    http://media.interactivepython.org/thinkcsVideos/Expressions.webm
-
 A **statement** is an instruction that the Python interpreter can execute. We
 have only seen the assignment statement so far.  Some other kinds of statements
 that we'll see shortly are ``while`` statements, ``for`` statements, ``if``


### PR DESCRIPTION
Resolves issue #19 / issue #75 

Adds a speed attribute to the turtle in Ex 3.8 in order to resolve the timeout error that occurs at default turtle speed. Makes no changes to introductory sentence which is a bit awkward.